### PR TITLE
fix: runtime exception on isLCAPEnabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.3",
     "@types/sinon": "^10.0.4",
-    "eslint": "7.32.0",
+    "eslint": "7.30.0",
     "@typescript-eslint/parser": "4.33.0",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "eslint-config-prettier": "8.3.0",

--- a/packages/app-studio-toolkit/.mocharc.js
+++ b/packages/app-studio-toolkit/.mocharc.js
@@ -1,7 +1,7 @@
 const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
-
 chai.use(chaiAsPromised);
+
 module.exports = {
   require: ["source-map-support/register"],
   spec: "./dist/test/**/*spec.js",

--- a/packages/app-studio-toolkit/package.json
+++ b/packages/app-studio-toolkit/package.json
@@ -43,7 +43,8 @@
     "string-replace-loader": "3.0.3",
     "webpack": "5.61.0",
     "webpack-cli": "4.9.1",
-    "proxyquire": "2.1.3"
+    "proxyquire": "2.1.3",
+    "p-defer": "3.0.0"
   },
   "activationEvents": [
     "*"

--- a/packages/app-studio-toolkit/package.json
+++ b/packages/app-studio-toolkit/package.json
@@ -30,19 +30,20 @@
   "dependencies": {
     "@sap/artifact-management": "1.1.0",
     "@vscode-logging/wrapper": "1.0.1",
-    "lodash": "4.17.21",
-    "optional-require": "1.0.3"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@sap-devx/app-studio-toolkit-types": "^1.3.0",
     "@types/lodash": "^4.14.168",
+    "@types/proxyquire": "1.3.28",
     "@vscode-logging/types": "0.1.4",
     "copy-webpack-plugin": "9.0.1",
     "fs-extra": "^10.0.0",
     "mock-require": "^3.0.3",
     "string-replace-loader": "3.0.3",
     "webpack": "5.61.0",
-    "webpack-cli": "4.9.1"
+    "webpack-cli": "4.9.1",
+    "proxyquire": "2.1.3"
   },
   "activationEvents": [
     "*"

--- a/packages/app-studio-toolkit/src/actions/controller.ts
+++ b/packages/app-studio-toolkit/src/actions/controller.ts
@@ -84,6 +84,7 @@ export class ActionsController {
     });
     forEach(actionsIds, async (actionId) => {
       const action = ActionsController.getAction(actionId.trim());
+      /* istanbul ignore else - testing logger flows not worth the cost... */
       if (action) {
         await _performAction(action);
       } else {

--- a/packages/app-studio-toolkit/src/apis/parameters.ts
+++ b/packages/app-studio-toolkit/src/apis/parameters.ts
@@ -1,12 +1,12 @@
 import { getLogger } from "../logger/logger";
+import { optionalRequire } from "../utils/optional-require";
 
 export async function getParameter(
   parameterName: string
 ): Promise<string | undefined> {
   const logger = getLogger().getChildLogger({ label: "getParameter" });
-  const optionalRequire = require("optional-require")(require);
   const noSapPlugin = "NO_SAP_PLUGIN_FOUND";
-  const sapPlugin = optionalRequire("@sap/plugin") ?? noSapPlugin;
+  const sapPlugin = optionalRequire<any>("@sap/plugin") ?? noSapPlugin;
 
   if (sapPlugin === noSapPlugin) {
     logger.trace("Failed to load @sap/plugin, so returning undefined.");

--- a/packages/app-studio-toolkit/src/apis/validateLCAP.ts
+++ b/packages/app-studio-toolkit/src/apis/validateLCAP.ts
@@ -1,10 +1,10 @@
 import { getLogger } from "../logger/logger";
+import { optionalRequire } from "../utils/optional-require";
 
 export async function isLCAPEnabled(): Promise<boolean | undefined> {
   const logger = getLogger().getChildLogger({ label: "isLCAPEnabled" });
-  const optionalRequire = require("optional-require")(require);
   const noSapPlugin = "NO_SAP_PLUGIN_FOUND";
-  const sapPlugin = optionalRequire("@sap/plugin") ?? noSapPlugin;
+  const sapPlugin = optionalRequire<any>("@sap/plugin") ?? noSapPlugin;
 
   if (sapPlugin === noSapPlugin) {
     logger.trace("Failed to load @sap/plugin, so returning undefined.");

--- a/packages/app-studio-toolkit/src/utils/native-require.ts
+++ b/packages/app-studio-toolkit/src/utils/native-require.ts
@@ -1,0 +1,5 @@
+// by avoiding parsing (and transformations) or webpack on this file
+//   - see webpack.config.js
+// we allow access to the native requirejs functionality for modules which import
+// this `native-require` file.
+export const nativeRequire: NodeRequire = require;

--- a/packages/app-studio-toolkit/src/utils/optional-require.ts
+++ b/packages/app-studio-toolkit/src/utils/optional-require.ts
@@ -1,3 +1,4 @@
+import { nativeRequire } from "./native-require";
 /**
  * Naive implementation of optional-require.
  * It does not deal with all edge cases, e.g differentiate between:
@@ -17,8 +18,8 @@ export function optionalRequire<M = unknown>(
 ): M | undefined {
   try {
     // will throw "MODULE_NOT_FOUND" if the module cannot be located
-    require.resolve(moduleName);
-    return require(moduleName) as M;
+    nativeRequire.resolve(moduleName);
+    return nativeRequire(moduleName) as M;
   } catch (e) {
     // our incredibly naive implementation does not currently distinguish between
     // "MODULE_NOT_FOUND" exceptions or exceptions thrown during the optional module loading

--- a/packages/app-studio-toolkit/src/utils/optional-require.ts
+++ b/packages/app-studio-toolkit/src/utils/optional-require.ts
@@ -1,0 +1,28 @@
+/**
+ * Naive implementation of optional-require.
+ * It does not deal with all edge cases, e.g differentiate between:
+ * 1. a module which does not exist.
+ * 2. a module which exists but throws an error on initialization.
+ *
+ * But our use cases are simple enough that this naive implementation should suffice.
+ * And this resolves bundling issue around the combination of:
+ * - webpack
+ * - optional-require npm package
+ * - pnpm (which creates sym-links in node_modules)
+ * - vsce vsix packager (which does **not** copy contents of sym-links).
+ *
+ */
+export function optionalRequire<M = unknown>(
+  moduleName: string
+): M | undefined {
+  try {
+    const modulePath = require.resolve(moduleName);
+    if (modulePath) {
+      return require(moduleName) as M;
+    } else {
+      return undefined;
+    }
+  } catch (e) {
+    return undefined;
+  }
+}

--- a/packages/app-studio-toolkit/src/utils/optional-require.ts
+++ b/packages/app-studio-toolkit/src/utils/optional-require.ts
@@ -16,13 +16,12 @@ export function optionalRequire<M = unknown>(
   moduleName: string
 ): M | undefined {
   try {
-    const modulePath = require.resolve(moduleName);
-    if (modulePath) {
-      return require(moduleName) as M;
-    } else {
-      return undefined;
-    }
+    // will throw "MODULE_NOT_FOUND" if the module cannot be located
+    require.resolve(moduleName);
+    return require(moduleName) as M;
   } catch (e) {
+    // our incredibly naive implementation does not currently distinguish between
+    // "MODULE_NOT_FOUND" exceptions or exceptions thrown during the optional module loading
     return undefined;
   }
 }

--- a/packages/app-studio-toolkit/test/apis/parameters.spec.ts
+++ b/packages/app-studio-toolkit/test/apis/parameters.spec.ts
@@ -1,102 +1,82 @@
-import * as proxyquire from "proxyquire";
 import { expect } from "chai";
-import { mockVscode } from "../mockUtil";
+import * as proxyquire from "proxyquire";
+import { NOOP_LOGGER } from "@vscode-logging/wrapper";
 
-const testVscode = {
-  window: {
-    createOutputChannel: () => "",
-  },
-  ExtensionContext: {},
-};
+type GetParamSignature = (parameterName: string) => Promise<string | undefined>;
 
-mockVscode(testVscode, "dist/src/logger/logger.js");
-import { getParameter } from "../../src/apis/parameters";
+describe("the getParameters utility", () => {
+  function buildGetParamProxy(optionalRequireMock: any): GetParamSignature {
+    const proxiedModule = proxyquire("../../src/apis/parameters", {
+      "../utils/optional-require": {
+        optionalRequire(): any {
+          return optionalRequireMock;
+        },
+      },
+      "../logger/logger": { getLogger: () => NOOP_LOGGER },
+    });
+    return proxiedModule.getParameter as GetParamSignature;
+  }
 
-describe("getParameter API", () => {
-  const parameterName = "param1";
-
-  it("should return undefined", async () => {
-    const parameterValue = await getParameter(parameterName);
-    expect(parameterValue).to.be.undefined;
-  });
-
-  // no test for configuration is undefined, because . behaves the same on null and undefined
-  describe("when configuration is null", () => {
-    let requireMock: any;
+  describe("when @sap/plugin is found", () => {
+    let getParameterProxy: GetParamSignature;
 
     before(() => {
-      requireMock = require("mock-require");
       const sapPlugin = {
         window: {
-          configuration: () => null,
+          configuration: () => ({ ima_aba: "bamba" }),
         },
       };
-      requireMock("@sap/plugin", sapPlugin);
+      getParameterProxy = buildGetParamProxy(sapPlugin);
     });
 
-    it("should return undefined", async () => {
-      const parameterValue = await getParameter(parameterName);
-      expect(parameterValue).to.be.undefined;
-    });
-
-    after(() => {
-      requireMock.stop("@sap/plugin");
+    it("returns its `window.configuration()` ", async () => {
+      await expect(getParameterProxy("ima_aba")).to.eventually.equal("bamba");
     });
   });
 
-  // no test for configuration containing other parameters, because [] --> to 'member access' behaves the same
-  describe("when configuration is empty", () => {
-    let requireMock: any;
+  describe("when @sap/plugin is not found", () => {
+    let getParameterProxy: GetParamSignature;
 
     before(() => {
-      requireMock = require("mock-require");
+      getParameterProxy = buildGetParamProxy(null);
+    });
+
+    it("returns undefined` ", async () => {
+      await expect(getParameterProxy("actions")).to.eventually.be.undefined;
+    });
+  });
+
+  describe("when @sap/plugin has an invalid configuration() value", () => {
+    let getParameterProxy: GetParamSignature;
+
+    before(() => {
       const sapPlugin = {
         window: {
-          configuration: () => "",
+          configuration: () => undefined,
         },
       };
-      requireMock("@sap/plugin", sapPlugin);
+      getParameterProxy = buildGetParamProxy(sapPlugin);
     });
 
-    it("should return undefined", async () => {
-      const parameterValue = await getParameter(parameterName);
-      expect(parameterValue).to.be.undefined;
-    });
-
-    after(() => {
-      requireMock.stop("@sap/plugin");
+    it("returns", async () => {
+      await expect(getParameterProxy("foo")).to.eventually.be.undefined;
     });
   });
 
-  // no test for value is undefined or null, because [] behaves the same on any value
-  describe("when configuration contains the parameter name", () => {
-    let getParameter: (parameterName: string) => Promise<string | undefined>;
+  describe("when @sap/plugin['configuration'] lacks the requested parameters", () => {
+    let getParameterProxy: GetParamSignature;
 
     before(() => {
-      const configuration = { param1: "bamba" };
-
-      const parametersModule = proxyquire("../../src/apis/parameters", {
-        "../utils/optional-require": {
-          optionalRequire() {
-            const sapPlugin = {
-              window: {
-                configuration: () => configuration,
-              },
-            };
-            return sapPlugin;
-          },
+      const sapPlugin = {
+        window: {
+          configuration: () => ({ foo: "666" }),
         },
-      });
-      getParameter = parametersModule.getParameter;
+      };
+      getParameterProxy = buildGetParamProxy(sapPlugin);
     });
 
-    it("should return parameter value", async () => {
-      const parameterValue = await getParameter(parameterName);
-      expect(parameterValue).to.be.equal("bamba");
-    });
-
-    after(() => {
-      requireMock.stop("@sap/plugin");
+    it("returns", async () => {
+      await expect(getParameterProxy("bar")).to.eventually.be.undefined;
     });
   });
 });

--- a/packages/app-studio-toolkit/test/apis/parameters.spec.ts
+++ b/packages/app-studio-toolkit/test/apis/parameters.spec.ts
@@ -1,3 +1,4 @@
+import * as proxyquire from "proxyquire";
 import { expect } from "chai";
 import { mockVscode } from "../mockUtil";
 
@@ -69,23 +70,29 @@ describe("getParameter API", () => {
 
   // no test for value is undefined or null, because [] behaves the same on any value
   describe("when configuration contains the parameter name", () => {
-    let requireMock: any;
-    const expectedParameterValue = "param1value";
+    let getParameter: (parameterName: string) => Promise<string | undefined>;
 
     before(() => {
-      requireMock = require("mock-require");
-      const configuration = { param1: expectedParameterValue };
-      const sapPlugin = {
-        window: {
-          configuration: () => configuration,
+      const configuration = { param1: "bamba" };
+
+      const parametersModule = proxyquire("../../src/apis/parameters", {
+        "../utils/optional-require": {
+          optionalRequire() {
+            const sapPlugin = {
+              window: {
+                configuration: () => configuration,
+              },
+            };
+            return sapPlugin;
+          },
         },
-      };
-      requireMock("@sap/plugin", sapPlugin);
+      });
+      getParameter = parametersModule.getParameter;
     });
 
     it("should return parameter value", async () => {
       const parameterValue = await getParameter(parameterName);
-      expect(parameterValue).to.be.equal(expectedParameterValue);
+      expect(parameterValue).to.be.equal("bamba");
     });
 
     after(() => {

--- a/packages/app-studio-toolkit/test/controller.spec.ts
+++ b/packages/app-studio-toolkit/test/controller.spec.ts
@@ -1,7 +1,10 @@
+import * as proxyquire from "proxyquire";
+import * as pDefer from "p-defer";
 import { expect } from "chai";
 import { mockVscode } from "./mockUtil";
 import { SinonSandbox, SinonMock, createSandbox } from "sinon";
 import { set } from "lodash";
+import { BasAction } from "@sap-devx/app-studio-toolkit-types";
 import { IChildLogger } from "@vscode-logging/types";
 
 const wsConfig = {
@@ -147,77 +150,140 @@ describe("controller unit test", () => {
     });
   });
 
-  describe("performActionsFromURL", () => {
-    const scheduledAction = {
-      name: "workbench.action.openGlobalSettings",
-      actionType: "COMMAND",
-      id: "openSettingsAction",
-    };
-    const action = ActionsFactory.createAction(scheduledAction, true);
+  describe("performAction", () => {
+    context("byIDs", () => {
+      context("performActionsFromURL()", () => {
+        let actionCtrlProxy: typeof ActionsController;
+        let performActionArgsPromise: Promise<BasAction>;
 
-    it.skip("_performAction should be called", async () => {
-      // TODO: proxyquire `ActionsController` with mock for `getParameter` instead of relying on deep transitive mocks
-      performerMock.expects("_performAction").withExactArgs(action).resolves();
-      await ActionsController.performActionsFromURL();
-    });
+        before(() => {
+          const performActionDeferred = pDefer<BasAction>();
+          performActionArgsPromise = performActionDeferred.promise;
 
-    it("throw error", () => {
-      const api = {
-        packageJSON: {
-          BASContributes: {
-            actions: [
-              {
-                id: "create",
-                actionType: "CREATE",
-                name: "create",
+          const proxyControllerModule = proxyquire(
+            "../src/actions/controller",
+            {
+              "../apis/parameters": {
+                getParameter() {
+                  // by "ids" structure (no array)
+                  return "openSettingsAction";
+                },
               },
-            ],
+              "./performer": {
+                _performAction(action: BasAction) {
+                  performActionDeferred.resolve(action);
+                },
+              },
+              vscode: {
+                extensions: {
+                  all: [
+                    {
+                      packageJSON: {
+                        BASContributes: {
+                          actions: [
+                            {
+                              // `id` matches `getParameter()` result above
+                              id: "openSettingsAction",
+                              actionType: "COMMAND",
+                              name: "workbench.action.openGlobalSettings",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  ],
+                },
+                "@noCallThru": true,
+              },
+            }
+          );
+
+          actionCtrlProxy = proxyControllerModule.ActionsController;
+          actionCtrlProxy.loadContributedActions();
+        });
+
+        it("performActionsFromURL call to performFullActions bamba", async () => {
+          const expectedAction = ActionsFactory.createAction(
+            {
+              name: "workbench.action.openGlobalSettings",
+              actionType: "COMMAND",
+              id: "openSettingsAction",
+            },
+            true
+          );
+
+          await actionCtrlProxy.performActionsFromURL();
+          await expect(performActionArgsPromise).to.eventually.deep.equal(
+            expectedAction
+          );
+        });
+      });
+
+      it("throw error", () => {
+        const api = {
+          packageJSON: {
+            BASContributes: {
+              actions: [
+                {
+                  id: "create",
+                  actionType: "CREATE",
+                  name: "create",
+                },
+              ],
+            },
           },
-        },
-      };
-      const testError = new Error(
-        `Failed to execute scheduled action ${JSON.stringify(
-          api.packageJSON.BASContributes.actions[0]
-        )}`
-      );
-      try {
-        ActionsController.performScheduledActions();
-      } catch (error) {
-        expect(error).to.be.equal(testError);
-      }
+        };
+        const testError = new Error(
+          `Failed to execute scheduled action ${JSON.stringify(
+            api.packageJSON.BASContributes.actions[0]
+          )}`
+        );
+        try {
+          ActionsController.performScheduledActions();
+        } catch (error) {
+          expect(error).to.be.equal(testError);
+        }
+      });
     });
   });
 
-  describe("perfomInlinedActions", () => {
-    context("call to performActionsFromURL", () => {
-      let requireMock: any;
+  context("inlined", () => {
+    context("performActionsFromURL()", () => {
+      let actionCtrlProxy: typeof ActionsController;
+      let performActionArgsPromise: Promise<BasAction>;
+
       before(() => {
-        requireMock = require("mock-require");
-        const configuration = {
-          actions: `[{"actionType":"COMMAND","name":"workbench.action.openSettings"}]`,
-        };
-        const sapPlugin = {
-          window: {
-            configuration: () => configuration,
+        const performActionDeferred = pDefer<BasAction>();
+        performActionArgsPromise = performActionDeferred.promise;
+
+        const proxyControllerModule = proxyquire("../src/actions/controller", {
+          "../apis/parameters": {
+            getParameter() {
+              // **inlined** json structured
+              return '[{"actionType":"COMMAND","name":"workbench.action.openSettings"}]';
+            },
           },
-        };
-        requireMock("@sap/plugin", sapPlugin);
-      });
-      after(() => {
-        requireMock.stop("@sap/plugin");
+          "./performer": {
+            _performAction(action: BasAction) {
+              performActionDeferred.resolve(action);
+            },
+          },
+          vscode: { ...testVscode, "@noCallThru": true },
+        });
+
+        actionCtrlProxy = proxyControllerModule.ActionsController;
       });
 
       it("performActionsFromURL call to perfomFullActions", async () => {
-        const action = ActionsFactory.createAction(
+        const expectedAction = ActionsFactory.createAction(
           { actionType: "COMMAND", name: "workbench.action.openSettings" },
           true
         );
 
-        performerMock
-          .expects("_performAction")
-          .withExactArgs(action)
-          .resolves();
-        await ActionsController.performActionsFromURL();
+        await actionCtrlProxy.performActionsFromURL();
+        await expect(performActionArgsPromise).to.eventually.deep.equal(
+          expectedAction
+        );
       });
     });
 

--- a/packages/app-studio-toolkit/test/controller.spec.ts
+++ b/packages/app-studio-toolkit/test/controller.spec.ts
@@ -155,7 +155,8 @@ describe("controller unit test", () => {
     };
     const action = ActionsFactory.createAction(scheduledAction, true);
 
-    it("_performAction should be called", async () => {
+    it.skip("_performAction should be called", async () => {
+      // TODO: proxyquire `ActionsController` with mock for `getParameter` instead of relying on deep transitive mocks
       performerMock.expects("_performAction").withExactArgs(action).resolves();
       await ActionsController.performActionsFromURL();
     });

--- a/packages/app-studio-toolkit/test/utils/optional-require.spec.ts
+++ b/packages/app-studio-toolkit/test/utils/optional-require.spec.ts
@@ -8,6 +8,27 @@ describe("the optionalRequire utility", () => {
     expect(tinManHeart).to.be.undefined;
   });
 
+  context("with a module that throws an error during init", () => {
+    before(() => {
+      delete (global as any).basketBall;
+    });
+
+    it("silently return undefined if a module throws an error", () => {
+      expect((global as any).basketBall).to.be.undefined;
+      const optionalModule = optionalRequire(
+        // local require reference not supported
+        // so we have to pass the path relative to our `optional-require` module
+        "../../test/utils/samples/throwing-module"
+      );
+      expect(optionalModule).to.be.undefined;
+      expect((global as any).basketBall).to.be.true;
+    });
+
+    after(() => {
+      delete (global as any).basketBall;
+    });
+  });
+
   it("returns the module if it exist", () => {
     // `crypto` is built-in in nodejs and should always be available
     const cryptoBubble = optionalRequire("crypto");

--- a/packages/app-studio-toolkit/test/utils/optional-require.spec.ts
+++ b/packages/app-studio-toolkit/test/utils/optional-require.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+import { optionalRequire } from "../../src/utils/optional-require";
+
+describe("the optionalRequire utility", () => {
+  it("return undefined if a module does not exist", () => {
+    // unicode heart is not a valid module name (at least currently).
+    const tinManHeart = optionalRequire("♥");
+    expect(tinManHeart).to.be.undefined;
+  });
+
+  it("returns the module if it exist", () => {
+    // `crypto` is built-in in nodejs and should always be available
+    const cryptoBubble = optionalRequire("crypto");
+    expect(cryptoBubble).to.exist;
+    // @ts-expect-error -- dynamic import
+    expect(cryptoBubble.Cipher).to.exist;
+  });
+});

--- a/packages/app-studio-toolkit/test/utils/samples/throwing-module.ts
+++ b/packages/app-studio-toolkit/test/utils/samples/throwing-module.ts
@@ -1,0 +1,3 @@
+// @ts-expect-error -- go away evil compiler, this is test dummy code...
+global.basketBall = true;
+throw "BasketBall";

--- a/packages/app-studio-toolkit/webpack.config.js
+++ b/packages/app-studio-toolkit/webpack.config.js
@@ -11,18 +11,9 @@ const config = Object.assign({}, baseConfig, {
     devtoolModuleFilenameTemplate: "../[resource-path]",
   },
   module: {
-    rules: [
-      {
-        test: /.*.js$/,
-        loader: "string-replace-loader",
-        options: {
-          // When bundling the `optional-require` flow must not be modified by webpack.
-          search: 'require("optional-require")(require)',
-          replace:
-            "__non_webpack_require__('optional-require')(__non_webpack_require__)",
-        },
-      },
-    ],
+    // https://webpack.js.org/configuration/module/#modulenoparse
+    // used to avoid transforming native require usage in `optional-require` implementation
+    noParse: /native-require\.(js|ts)$/,
   },
   // 📖 -> https://webpack.js.org/configuration/externals/
   externals: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
       chai-as-promised: ^7.1.1
       coveralls: ^3.1.1
       cz-conventional-changelog: 3.3.0
-      eslint: 7.32.0
+      eslint: 7.30.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
       husky: 7.0.4
@@ -46,15 +46,15 @@ importers:
       '@types/node': 16.11.6
       '@types/sinon': 10.0.6
       '@types/vscode': 1.61.0
-      '@typescript-eslint/eslint-plugin': 4.33.0_cc617358c89d3f38c52462f6d809db4c
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 4.33.0_3ce8a7c1f9afe79f00cf11407b47f3f5
+      '@typescript-eslint/parser': 4.33.0_eslint@7.30.0+typescript@4.4.4
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       coveralls: 3.1.1
       cz-conventional-changelog: 3.3.0
-      eslint: 7.32.0
-      eslint-config-prettier: 8.3.0_eslint@7.32.0
-      eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
+      eslint: 7.30.0
+      eslint-config-prettier: 8.3.0_eslint@7.30.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@7.30.0
       husky: 7.0.4
       lerna: 4.0.0
       lint-staged: 11.2.0
@@ -1629,7 +1629,7 @@ packages:
   /@types/vscode/1.61.0:
     resolution: {integrity: sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==}
 
-  /@typescript-eslint/eslint-plugin/4.33.0_cc617358c89d3f38c52462f6d809db4c:
+  /@typescript-eslint/eslint-plugin/4.33.0_3ce8a7c1f9afe79f00cf11407b47f3f5:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1640,11 +1640,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.4.4
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
+      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.30.0+typescript@4.4.4
+      '@typescript-eslint/parser': 4.33.0_eslint@7.30.0+typescript@4.4.4
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.2
-      eslint: 7.32.0
+      eslint: 7.30.0
       functional-red-black-tree: 1.0.1
       ignore: 5.1.8
       regexpp: 3.2.0
@@ -1655,7 +1655,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.33.0_eslint@7.32.0+typescript@4.4.4:
+  /@typescript-eslint/experimental-utils/4.33.0_eslint@7.30.0+typescript@4.4.4:
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1665,15 +1665,15 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.4.4
-      eslint: 7.32.0
+      eslint: 7.30.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.32.0
+      eslint-utils: 3.0.0_eslint@7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_eslint@7.32.0+typescript@4.4.4:
+  /@typescript-eslint/parser/4.33.0_eslint@7.30.0+typescript@4.4.4:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1687,7 +1687,7 @@ packages:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.4.4
       debug: 4.3.2
-      eslint: 7.32.0
+      eslint: 7.30.0
       typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
@@ -3269,23 +3269,23 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier/8.3.0_eslint@7.32.0:
+  /eslint-config-prettier/8.3.0_eslint@7.30.0:
     resolution: {integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 7.32.0
+      eslint: 7.30.0
     dev: true
 
-  /eslint-plugin-eslint-comments/3.2.0_eslint@7.32.0:
+  /eslint-plugin-eslint-comments/3.2.0_eslint@7.30.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
       escape-string-regexp: 1.0.5
-      eslint: 7.32.0
+      eslint: 7.30.0
       ignore: 5.1.8
     dev: true
 
@@ -3304,13 +3304,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@7.32.0:
+  /eslint-utils/3.0.0_eslint@7.30.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 7.32.0
+      eslint: 7.30.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -3324,8 +3324,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint/7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
+  /eslint/7.30.0:
+    resolution: {integrity: sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
     dependencies:
@@ -7727,7 +7727,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
 
   /wildcard/2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,13 +86,14 @@ importers:
       '@sap-devx/app-studio-toolkit-types': ^1.3.0
       '@sap/artifact-management': 1.1.0
       '@types/lodash': ^4.14.168
+      '@types/proxyquire': 1.3.28
       '@vscode-logging/types': 0.1.4
       '@vscode-logging/wrapper': 1.0.1
       copy-webpack-plugin: 9.0.1
       fs-extra: ^10.0.0
       lodash: 4.17.21
       mock-require: ^3.0.3
-      optional-require: 1.0.3
+      proxyquire: 2.1.3
       string-replace-loader: 3.0.3
       webpack: 5.61.0
       webpack-cli: 4.9.1
@@ -100,14 +101,15 @@ importers:
       '@sap/artifact-management': 1.1.0
       '@vscode-logging/wrapper': 1.0.1
       lodash: 4.17.21
-      optional-require: 1.0.3
     devDependencies:
       '@sap-devx/app-studio-toolkit-types': link:../app-studio-toolkit-types
       '@types/lodash': 4.14.176
+      '@types/proxyquire': 1.3.28
       '@vscode-logging/types': 0.1.4
       copy-webpack-plugin: 9.0.1_webpack@5.61.0
       fs-extra: 10.0.0
       mock-require: 3.0.3
+      proxyquire: 2.1.3
       string-replace-loader: 3.0.3_webpack@5.61.0
       webpack: 5.61.0_webpack-cli@4.9.1
       webpack-cli: 4.9.1_webpack@5.61.0
@@ -1610,6 +1612,10 @@ packages:
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: true
+
+  /@types/proxyquire/1.3.28:
+    resolution: {integrity: sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==}
     dev: true
 
   /@types/sinon/10.0.6:
@@ -3547,6 +3553,14 @@ packages:
       minimatch: 3.0.4
     dev: false
 
+  /fill-keys/1.0.2:
+    resolution: {integrity: sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-object: 1.0.2
+      merge-descriptors: 1.0.1
+    dev: true
+
   /fill-range/7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
@@ -4400,6 +4414,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-object/1.0.2:
+    resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
+    dev: true
+
   /is-plain-obj/1.1.0:
     resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
     engines: {node: '>=0.10.0'}
@@ -5105,6 +5123,10 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
+  /merge-descriptors/1.0.1:
+    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
+    dev: true
+
   /merge-stream/2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
@@ -5324,6 +5346,10 @@ packages:
   /modify-values/1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /module-not-found-error/1.0.1:
+    resolution: {integrity: sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=}
     dev: true
 
   /moment/2.29.1:
@@ -6176,6 +6202,14 @@ packages:
 
   /protocols/1.4.8:
     resolution: {integrity: sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==}
+    dev: true
+
+  /proxyquire/2.1.3:
+    resolution: {integrity: sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==}
+    dependencies:
+      fill-keys: 1.0.2
+      module-not-found-error: 1.0.1
+      resolve: 1.20.0
     dev: true
 
   /psl/1.8.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,7 @@ importers:
       fs-extra: ^10.0.0
       lodash: 4.17.21
       mock-require: ^3.0.3
+      p-defer: 3.0.0
       proxyquire: 2.1.3
       string-replace-loader: 3.0.3
       webpack: 5.61.0
@@ -109,6 +110,7 @@ importers:
       copy-webpack-plugin: 9.0.1_webpack@5.61.0
       fs-extra: 10.0.0
       mock-require: 3.0.3
+      p-defer: 3.0.0
       proxyquire: 2.1.3
       string-replace-loader: 3.0.3_webpack@5.61.0
       webpack: 5.61.0_webpack-cli@4.9.1
@@ -5795,6 +5797,11 @@ packages:
     dependencies:
       os-homedir: 1.0.2
       os-tmpdir: 1.0.2
+    dev: true
+
+  /p-defer/3.0.0:
+    resolution: {integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==}
+    engines: {node: '>=8'}
     dev: true
 
   /p-finally/1.0.0:


### PR DESCRIPTION
The cause of the runtime exception is that `optional-require` was not bundled
inside the vsix as:
1. bundling it with webpack into `extension.js` does not work as it uses node.js built in module system apis.
2. bundling it with VSCE does not work as VSCE does not seem to follow sym-links.

The alternative is to implement our own naïve `optionalRequire` implementation and thus avoid the problem.

Left to do:
- [ ] verify how exactly our own utility is transformed during bundling:
      - `require.resolve()` api
      - `require()` api
      - May need to exclude those calls (e.g NON_WEBPACK_REQUIRE)
- [ ] fix last failing test to mock direct dependency with `proxyquire` instead of in-direct dependency with `mock-require`
- [ ] inspect code coverage report