### PR TITLE
fix: support for identifying LCAP mode also for vscode

### DIFF
--- a/packages/app-studio-toolkit-types/api.d.ts
+++ b/packages/app-studio-toolkit-types/api.d.ts
@@ -97,7 +97,7 @@ export interface BasToolkit {
    * @returns true is environment is LCAP in BAS,
    *          `undefined` otherwise.
    */
-  isLCAPEnabled: () => Promise<boolean | undefined>;
+  isLCAPEnabled: () => Promise<boolean>;
 
   /**
    * Determine whether BAS is opened for running action or editing a project

--- a/packages/app-studio-toolkit/src/apis/validateLCAP.ts
+++ b/packages/app-studio-toolkit/src/apis/validateLCAP.ts
@@ -1,19 +1,14 @@
-import { getLogger } from "../logger/logger";
-import { optionalRequire } from "../utils/optional-require";
+import { getLogger } from "@sap/artifact-management";
+import { extensions } from "vscode";
 
-export async function isLCAPEnabled(): Promise<boolean | undefined> {
+export const LACP_EXTENSION_ID = "SAPSE.lcap-cockpit";
+
+export async function isLCAPEnabled(): Promise<boolean> {
   const logger = getLogger().getChildLogger({ label: "isLCAPEnabled" });
-  const noSapPlugin = "NO_SAP_PLUGIN_FOUND";
-  const sapPlugin = optionalRequire<any>("@sap/plugin") ?? noSapPlugin;
 
-  if (sapPlugin === noSapPlugin) {
-    logger.trace("Failed to load @sap/plugin, so returning undefined.");
-    return;
-  }
-  logger.trace("@sap/plugin successfully loaded.");
+  // LCAP mode is determined by the existence of the LCAP extension
+  const isLCAPEnabled = !!extensions.getExtension(LACP_EXTENSION_ID);
+  logger.trace("LCAP enabled mode", { isLCAPEnabled });
 
-  const isLCAPEnabled = await sapPlugin.window.isLCAPEnabled();
-  logger.trace("LCAP enabled successfully received.", { isLCAPEnabled });
-
-  return isLCAPEnabled as boolean | undefined;
+  return Promise.resolve(isLCAPEnabled);
 }


### PR DESCRIPTION
### What it does:
Updates the way to identify LCAP mode to be determined by the existence of the LCAP (cockpit) extension,
this should be right both for theia & vscode

- [x]  Tested locally with the `app-studio-toolkit` and `lcap-cockpit` extensions `vsix` 