### PR TITLE
chore: update dependency @sap/artifact-management to v1.20.1

### DIFF
--- a/packages/app-studio-toolkit-types/api.d.ts
+++ b/packages/app-studio-toolkit-types/api.d.ts
@@ -63,7 +63,7 @@ export interface NodeUpgradeSpec {
 
 export type BasWorkspaceApi = Pick<
   WorkspaceApi,
-  "getProjects" | "getProjectUris" | "onWorkspaceChanged"
+  "getProjects" | "getProject" | "getProjectUris" | "onWorkspaceChanged"
 >;
 
 export interface BasToolkit {

--- a/packages/app-studio-toolkit-types/package.json
+++ b/packages/app-studio-toolkit-types/package.json
@@ -20,7 +20,7 @@
     "compile": "tsc -p ."
   },
   "dependencies": {
-    "@sap/artifact-management-types": "1.19.1",
+    "@sap/artifact-management-types": "1.20.1",
     "@types/vscode": "^1.49.0",
     "@vscode-logging/types": "0.1.4",
     "type-fest": "2.11.1"

--- a/packages/app-studio-toolkit/package.json
+++ b/packages/app-studio-toolkit/package.json
@@ -28,7 +28,7 @@
     "package": "node ./scripts/package-vsix.js"
   },
   "dependencies": {
-    "@sap/artifact-management": "1.19.1",
+    "@sap/artifact-management": "1.20.1",
     "@vscode-logging/wrapper": "1.0.1",
     "lodash": "4.17.21"
   },

--- a/packages/app-studio-toolkit/src/public-api/create-workspace-proxy.ts
+++ b/packages/app-studio-toolkit/src/public-api/create-workspace-proxy.ts
@@ -7,6 +7,8 @@ export function createWorkspaceProxy(
   const basWsAPI = {
     getProjects: (...args: Parameters<WorkspaceApi["getProjects"]>) =>
       workspaceImpl.getProjects(...args),
+    getProject: (...args: Parameters<WorkspaceApi["getProject"]>) =>
+      workspaceImpl.getProject(...args),
     getProjectUris: (...args: Parameters<WorkspaceApi["getProjectUris"]>) =>
       workspaceImpl.getProjectUris(...args),
     onWorkspaceChanged: (

--- a/packages/app-studio-toolkit/test/public-api/create-bas-toolkit-api.spec.ts
+++ b/packages/app-studio-toolkit/test/public-api/create-bas-toolkit-api.spec.ts
@@ -40,6 +40,7 @@ describe("the `createBasToolkitAPI()` utility", () => {
       expect(basToolkit).to.have.property("workspaceAPI");
       expect(Object.keys(basToolkit.workspaceAPI)).to.have.members([
         "getProjects",
+        "getProject",
         "getProjectUris",
         "onWorkspaceChanged",
       ]);

--- a/packages/app-studio-toolkit/test/public-api/create-workspace-proxy.spec.ts
+++ b/packages/app-studio-toolkit/test/public-api/create-workspace-proxy.spec.ts
@@ -12,6 +12,9 @@ describe("the `createWorkspaceProxy` utility", () => {
       getProjects(...args: any[]) {
         return args;
       },
+      getProject(...args: any[]) {
+        return args;
+      },
       getProjectUris(...args: any[]) {
         return args;
       },
@@ -33,7 +36,7 @@ describe("the `createWorkspaceProxy` utility", () => {
     });
 
     it("exposes only three properties", () => {
-      expect(Object.keys(workspaceProxy)).to.have.lengthOf(3);
+      expect(Object.keys(workspaceProxy)).to.have.lengthOf(4);
     });
   });
 
@@ -45,6 +48,19 @@ describe("the `createWorkspaceProxy` utility", () => {
 
     it("passes through arguments", () => {
       expect(workspaceProxy.getProjects(Tag.CAP)).to.deep.equal([Tag.CAP]);
+    });
+  });
+
+  context("`getProject()` method", () => {
+    it("is exposed", () => {
+      expect(workspaceProxy).to.have.property("getProject");
+      expect(typeof workspaceProxy.getProject).to.equal("function");
+    });
+
+    it("passes through arguments", () => {
+      expect(workspaceProxy.getProject("dummyPath")).to.deep.equal([
+        "dummyPath",
+      ]);
     });
   });
 

--- a/packages/app-studio-toolkit/test/public-api/create-workspace-proxy.spec.ts
+++ b/packages/app-studio-toolkit/test/public-api/create-workspace-proxy.spec.ts
@@ -35,7 +35,7 @@ describe("the `createWorkspaceProxy` utility", () => {
       expect(workspaceProxy).to.be.sealed;
     });
 
-    it("exposes only three properties", () => {
+    it("exposes only four properties", () => {
       expect(Object.keys(workspaceProxy)).to.have.lengthOf(4);
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
   packages/app-studio-toolkit:
     specifiers:
       '@sap-devx/app-studio-toolkit-types': ^1.11.1
-      '@sap/artifact-management': 1.19.1
+      '@sap/artifact-management': 1.20.1
       '@types/lodash': ^4.14.168
       '@types/proxyquire': 1.3.28
       '@vscode-logging/types': 0.1.4
@@ -108,7 +108,7 @@ importers:
       p-defer: 3.0.0
       proxyquire: 2.1.3
     dependencies:
-      '@sap/artifact-management': 1.19.1
+      '@sap/artifact-management': 1.20.1
       '@vscode-logging/wrapper': 1.0.1
       lodash: 4.17.21
     devDependencies:
@@ -124,12 +124,12 @@ importers:
 
   packages/app-studio-toolkit-types:
     specifiers:
-      '@sap/artifact-management-types': 1.19.1
+      '@sap/artifact-management-types': 1.20.1
       '@types/vscode': ^1.49.0
       '@vscode-logging/types': 0.1.4
       type-fest: 2.11.1
     dependencies:
-      '@sap/artifact-management-types': 1.19.1
+      '@sap/artifact-management-types': 1.20.1
       '@types/vscode': 1.62.0
       '@vscode-logging/types': 0.1.4
       type-fest: 2.11.1
@@ -1592,8 +1592,8 @@ packages:
       '@octokit/openapi-types': 11.2.0
     dev: true
 
-  /@sap/artifact-management-base-types/1.19.1:
-    resolution: {integrity: sha512-wDRGNA4Hn1wZ8c7rKXnhlqVfO8P1Pd7P1cI34q4DGJk/0yAniSkq5wyRQ8HnHCp33z58RLK1d5rMmCuJtMVGRQ==}
+  /@sap/artifact-management-base-types/1.20.1:
+    resolution: {integrity: sha512-YdwToRrHhkR0dFQGhxiB0IIpxSg9IAtbhIY3yeM6839ysq7q5XraP/QM4hC7bsP5/3+uVbqQvRFuXF0hY8HRSw==}
     dependencies:
       '@types/node': 14.14.6
       '@types/vscode': 1.52.0
@@ -1601,8 +1601,8 @@ packages:
       vscode-languageserver-types: 3.16.0
     dev: false
 
-  /@sap/artifact-management-base/1.19.1:
-    resolution: {integrity: sha512-AoF1wCMhcQqyT6O4ZP80xq7G7yAZrMq+RMLVsPe+7YIGtlurQGoEl3FfvuxacdwlYHLNiDoHdeXlLFWKwNofuQ==}
+  /@sap/artifact-management-base/1.20.1:
+    resolution: {integrity: sha512-eyhweXSDDRK4Ch7vnc/oRyULoJDxO37ReoAeqmOfhX/p54cCPqOls51neolAuu9KiBjBeagx2mRTfCAbOTjBCQ==}
     engines: {node: ^14.14.0 || ^16.15.0}
     dependencies:
       ejs: 3.1.8
@@ -1617,40 +1617,40 @@ packages:
       winston-transport: 4.5.0
     dev: false
 
-  /@sap/artifact-management-hanaplugin/1.19.1:
-    resolution: {integrity: sha512-HS1AWmTlp+CwbEWpqErvbCSnNJQt5OPQO+OM/LLOA5AEa2aQ/w/lt6VW48kiHPzzqOfUUurMHK2lh6wH7QRxXA==}
+  /@sap/artifact-management-hanaplugin/1.20.1:
+    resolution: {integrity: sha512-ZGEgLIXf3CszazVwGCSM+EuEz+efgFRkMHd5+YeiLxg5Pl8cv/hvCA2+6fiVDAV7mnVfBXH0o//RqgOmdFjgWw==}
     dependencies:
-      '@sap/artifact-management-base': 1.19.1
+      '@sap/artifact-management-base': 1.20.1
       fast-glob: 3.2.7
       glob: 7.2.0
     dev: false
 
-  /@sap/artifact-management-mdkplugin/1.19.1:
-    resolution: {integrity: sha512-kCgVcNwrbaibL/b1ajSKMyi8a2YwzCJhYdL+VqVVvp63rZLOX6m0AmWt93GNv3hVKysU55/bEbH7lNksdjO+Kw==}
+  /@sap/artifact-management-mdkplugin/1.20.1:
+    resolution: {integrity: sha512-4yG10FE4aIbWr0dBkG1SquwDx2VZOfQ2S2YPA43bScZ8FWfY+v2mXHKWS9h++1SuXlIIzkqEmvvwTM3/x9SI6A==}
     dependencies:
-      '@sap/artifact-management-base': 1.19.1
+      '@sap/artifact-management-base': 1.20.1
     dev: false
 
-  /@sap/artifact-management-types/1.19.1:
-    resolution: {integrity: sha512-snzgK0AwxB1Lh2K2QsuKgSpk59saYmavr9uf4KXmV7gjqOYAEflm2PG4RvAJ6rLTVCpM2Z5LnEKLTL9L0DzLVQ==}
+  /@sap/artifact-management-types/1.20.1:
+    resolution: {integrity: sha512-33cAditAX2znPICIULBR7qgkrTs1bddSUQmtZyNUP6OwuI0OeXvUDAes7ME6USVxP7POAA++oSEwcV6QHfvZBw==}
     dependencies:
-      '@sap/artifact-management-base-types': 1.19.1
+      '@sap/artifact-management-base-types': 1.20.1
     dev: false
 
-  /@sap/artifact-management/1.19.1:
-    resolution: {integrity: sha512-ld4a3yPyXm9ynGl/Is7H8iN0Bkm2Wp8N7BJRgex7ilTD5tqeaJbkaqbqg+r6wmo8kIhYFOS8HTPkc8p+cao7sA==}
+  /@sap/artifact-management/1.20.1:
+    resolution: {integrity: sha512-03tP+Pqvp1wz8NNoH5ZoDBe8vKF2CPOaPZQ+lvROckqdR9mwwhJi1MrVu4eYOppMBRinRh82HE3ud0t7zv/Mcw==}
     hasBin: true
     dependencies:
-      '@sap/artifact-management-base': 1.19.1
-      '@sap/artifact-management-hanaplugin': 1.19.1
-      '@sap/artifact-management-mdkplugin': 1.19.1
+      '@sap/artifact-management-base': 1.20.1
+      '@sap/artifact-management-hanaplugin': 1.20.1
+      '@sap/artifact-management-mdkplugin': 1.20.1
       ajv: 8.8.1
       chokidar: 3.5.2
       js-yaml: 4.1.0
       lodash: 4.17.21
       micromatch: 4.0.4
       parse-gitignore: 1.0.1
-      simple-git: 3.16.0
+      simple-git: 3.16.1
       uuid: 8.3.2
       vscode-languageserver-types: 3.16.0
       xml2js: 0.4.23
@@ -6777,8 +6777,8 @@ packages:
     resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==}
     dev: true
 
-  /simple-git/3.16.0:
-    resolution: {integrity: sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==}
+  /simple-git/3.16.1:
+    resolution: {integrity: sha512-xzRxMKiy1zEYeHGXgAzvuXffDS0xgsq07Oi4LWEEcVH29vLpcZ2tyQRWyK0NLLlCVaKysZeem5tC1qHEOxsKwA==}
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1


### PR DESCRIPTION
There is a request of getting ProjectApi object by a specific path from cicd (https://jira.tools.sap/browse/LCAP-2883). Project API add a new api to support such request and release the patch 1.20.1 for it. So I submit the pull request to make cicd can use the new api via app-studio-toolkit.

As to refactor Project API to add  a new VSCode wrapper as npm module, there still are some concerns and require more time to clarify them on Project API side. 