### PR TITLE
ci: bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node_version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm run ci
 
       - name: upload build artifacts
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: upload_build_artifacts
         with:
           name: all-vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
       fail-fast: false
 
     steps:
-      # using `v1` because of: https://github.com/actions/checkout/issues/246
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           retention-days: ${{ env.artifact-retention-days }}
 
       - name: Find PR Comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         if: github.event_name == 'pull_request'
         id: find-pr-comment
         with:
@@ -68,7 +68,7 @@ jobs:
           body-includes: ${{ env.retention-comment }}
 
       - name: Create / Update PR Comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: github.event_name == 'pull_request'
         env:
           HEAD_SHA: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup pnpm
         # pnpm version from package.json `packageManager` field is used
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup pnpm
         # pnpm version from package.json `packageManager` field is used
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
       contents: write # Push version bump commits, create git tags, and upload release assets
       pull-requests: write # Create "Version Packages" PR via changesets/action
     steps:
-      # using `v1` because of: https://github.com/actions/checkout/issues/246
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # See: https://github.com/changesets/action/issues/187#issuecomment-1228413850
           token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           # See: https://github.com/changesets/action/issues/187#issuecomment-1228413850
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
 


### PR DESCRIPTION

## GitHub Actions Version Bumps

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v1 | **v6.0.2** |
| `actions/setup-node` | v4 | **v6.4.0** |
| `pnpm/action-setup` | v4 | **v6.0.8** |
| `actions/upload-artifact` | v4 | **v7.0.1** |
| `peter-evans/find-comment` | v3 | **v4.0.0** |
| `peter-evans/create-or-update-comment` | v4 | **v5.0.0** |
| `changesets/action` | v1.8.0 | *(already latest — no change)* |

All actions remain pinned to full commit SHAs for supply-chain protection.
