### PR TITLE
fix(webide-client-tools): increase bundleFeature test timeout to 20s

### DIFF
--- a/packages/webide-client-tools/test/bundling_spec.js
+++ b/packages/webide-client-tools/test/bundling_spec.js
@@ -378,7 +378,7 @@ describe("The, Exported bundling APIs", () => {
 
   function defineBundleFeatureSpecs(bundler) {
     describe(`bundleFeature API - ${bundler}`, () => {
-      const bundleTestTimeout = 10000
+      const bundleTestTimeout = 20000
       const distFolder = path.resolve(__dirname, "dist")
       const expectedJSOutputFile = `${distFolder}/config-preload.js`
       const expectedMetadataOutputFile = `${distFolder}/config-preload.json`


### PR DESCRIPTION
10s was too tight for webpack bundling on CI runners, causing a timeout that left stale dist folders and cascaded into a second failure (expected 1 timestamp folder, found 11).