### PR TITLE
ci: Review PR #496 - Reduce usage of token with elevated permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,9 @@ jobs:
     permissions:
       contents: write # Upload release assets via VSIX upload step
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Custom App Token needed to trigger transitive jobs from the PR
-          # See: https://github.com/changesets/action/issues/187#issuecomment-1228413850
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -41,6 +32,13 @@ jobs:
       - name: Build
         run: pnpm run ci
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: ChangeSets Release or PR creation
         id: changesets_release_or_pr
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
@@ -50,6 +48,7 @@ jobs:
           version: pnpm run ci:version
           publish: pnpm run ci:release
         env:
+          # Custom App Token needed to trigger transitive jobs from the PR
           # See: https://github.com/changesets/action/issues/187#issuecomment-1228413850
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
This commit refactors the `release.yml` workflow to to reduce the usage of the token generated with the GitHub app.

actions/checkout is now using the default token and not persisting credentials, as they are not needed (e.g., _Upload VSIX to releases_ receives the token through the environment.

The token is now generated just before it is needed.