### PR TITLE
fix: use workspace protocol for yeoman-ui-types dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         version: 2.0.8
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.104.1(webpack-cli@6.0.1))
+        version: 11.0.0(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1)))
       fs-extra:
         specifier: 11.1.1
         version: 11.1.1
@@ -196,10 +196,10 @@ importers:
         version: 3.0.0
       string-replace-loader:
         specifier: 3.1.0
-        version: 3.1.0(webpack@5.104.1(webpack-cli@6.0.1))
+        version: 3.1.0(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1)))
       ts-loader:
         specifier: 9.4.2
-        version: 9.4.2(typescript@4.5.2)(webpack@5.104.1(webpack-cli@6.0.1))
+        version: 9.4.2(typescript@4.5.2)(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1)))
 
   packages/app-studio-toolkit:
     dependencies:
@@ -278,7 +278,7 @@ importers:
         version: 2.0.8
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.104.1(webpack-cli@6.0.1))
+        version: 11.0.0(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1)))
       fs-extra:
         specifier: 11.1.1
         version: 11.1.1
@@ -290,10 +290,10 @@ importers:
         version: 3.0.0
       string-replace-loader:
         specifier: 3.1.0
-        version: 3.1.0(webpack@5.104.1(webpack-cli@6.0.1))
+        version: 3.1.0(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1)))
       ts-loader:
         specifier: 9.4.2
-        version: 9.4.2(typescript@4.5.2)(webpack@5.104.1(webpack-cli@6.0.1))
+        version: 9.4.2(typescript@4.5.2)(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1)))
 
   packages/app-studio-toolkit-themes: {}
 
@@ -534,7 +534,7 @@ importers:
         version: 2.25.3(@typescript-eslint/parser@4.33.0(eslint@7.30.0)(typescript@4.5.2))(eslint@7.30.0)
       jest:
         specifier: 27.5.1
-        version: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)
+        version: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)
 
   projects/yeoman-ui/packages/backend:
     dependencies:
@@ -542,8 +542,8 @@ importers:
         specifier: 0.4.1
         version: 0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@sap-devx/yeoman-ui-types':
-        specifier: ^1.25.0
-        version: 1.25.0
+        specifier: workspace:^
+        version: link:../types
       '@sap/bas-sdk':
         specifier: 3.13.7
         version: 3.13.7(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -699,8 +699,8 @@ importers:
         specifier: 0.4.1
         version: 0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@sap-devx/yeoman-ui-types':
-        specifier: ^1.25.0
-        version: 1.25.0
+        specifier: workspace:^
+        version: link:../types
       core-js:
         specifier: ^3.8.3
         version: 3.49.0
@@ -775,8 +775,8 @@ importers:
   projects/yeoman-ui/packages/generator-foodq:
     dependencies:
       '@sap-devx/yeoman-ui-types':
-        specifier: ^1.25.0
-        version: 1.25.0
+        specifier: workspace:^
+        version: link:../types
       chalk-pipe:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2398,9 +2398,6 @@ packages:
 
   '@sap-devx/webview-rpc@0.4.1':
     resolution: {integrity: sha512-FznAh7u1qZh4VWle6wxCmXL2/qI0QigRx67jsL/Eyn7lW1e+6CO2vShond5IjS6+YKpXL7WFwK2MnU08kqqM6A==}
-
-  '@sap-devx/yeoman-ui-types@1.25.0':
-    resolution: {integrity: sha512-eqiD0C5JmT5mMUbYaRO8YUfnlmSYZgB/ZMuh62G2196z9FG2ppayElzZMKWNGEgx5ZXFbbxJc6dVrny94I2vQA==}
 
   '@sap/artifact-management-base-types@1.53.2':
     resolution: {integrity: sha512-2bKF8Ns4vdPAEDCApdFXf9qaAN1XtvOvOhQyiYMeeG1KSTvnvHmeCVw0QPF1nvTOI+i8lOy/r0no5k0+fDoFlw==}
@@ -11495,7 +11492,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)':
+  '@jest/core@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1
@@ -11509,7 +11506,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)
+      jest-config: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
@@ -12313,8 +12310,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@sap-devx/yeoman-ui-types@1.25.0': {}
 
   '@sap/artifact-management-base-types@1.53.2':
     dependencies:
@@ -14506,7 +14501,7 @@ snapshots:
 
   copy-descriptor@0.1.1: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.104.1(webpack-cli@6.0.1)):
+  copy-webpack-plugin@11.0.0(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1))):
     dependencies:
       fast-glob: 3.2.12
       glob-parent: 6.0.2
@@ -14514,7 +14509,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.106.2(webpack-cli@6.0.1(webpack@5.104.1))
 
   copy-webpack-plugin@12.0.2(webpack@5.106.2):
     dependencies:
@@ -17119,16 +17114,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10):
+  jest-cli@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10):
     dependencies:
-      '@jest/core': 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)
+      '@jest/core': 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.0.3
-      jest-config: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)
+      jest-config: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -17178,7 +17173,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10):
+  jest-config@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 27.5.1
@@ -17205,7 +17200,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@16.11.10)(typescript@4.5.2)
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@4.5.2)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -17808,11 +17803,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10):
+  jest@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10):
     dependencies:
-      '@jest/core': 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)
+      '@jest/core': 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)
       import-local: 3.0.3
-      jest-cli: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@16.11.10)(typescript@4.5.2))(utf-8-validate@5.0.10)
+      jest-cli: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@4.5.2))(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -20639,11 +20634,11 @@ snapshots:
       schema-utils: 3.1.1
       webpack: 5.106.2(webpack-cli@5.1.4)
 
-  string-replace-loader@3.1.0(webpack@5.104.1(webpack-cli@6.0.1)):
+  string-replace-loader@3.1.0(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.106.2(webpack-cli@6.0.1(webpack@5.104.1))
 
   string-similarity@4.0.4: {}
 
@@ -21023,14 +21018,14 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.0)
       jest-util: 29.7.0
 
-  ts-loader@9.4.2(typescript@4.5.2)(webpack@5.104.1(webpack-cli@6.0.1)):
+  ts-loader@9.4.2(typescript@4.5.2)(webpack@5.106.2(webpack-cli@6.0.1(webpack@5.104.1))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.8.3
       micromatch: 4.0.4
       semver: 7.3.5
       typescript: 4.5.2
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.106.2(webpack-cli@6.0.1(webpack@5.104.1))
 
   ts-loader@9.4.2(typescript@4.5.2)(webpack@5.106.2):
     dependencies:

--- a/projects/yeoman-ui/packages/backend/package.json
+++ b/projects/yeoman-ui/packages/backend/package.json
@@ -179,7 +179,7 @@
   "activationEvents": [],
   "dependencies": {
     "@sap-devx/webview-rpc": "0.4.1",
-    "@sap-devx/yeoman-ui-types": "^1.25.0",
+    "@sap-devx/yeoman-ui-types": "workspace:^",
     "@sap/bas-sdk": "3.13.7",
     "@sap/swa-for-sapbas-vsx": "2.0.16",
     "@vscode-logging/logger": "2.0.9",

--- a/projects/yeoman-ui/packages/frontend/package.json
+++ b/projects/yeoman-ui/packages/frontend/package.json
@@ -78,7 +78,7 @@
     "@sap-devx/inquirer-gui-radio-plugin": "3.4.13",
     "@sap-devx/inquirer-gui-tiles-plugin": "3.4.13",
     "@sap-devx/webview-rpc": "0.4.1",
-    "@sap-devx/yeoman-ui-types": "^1.25.0",
+    "@sap-devx/yeoman-ui-types": "workspace:^",
     "core-js": "^3.8.3",
     "material-design-icons-iconfont": "6.1.0",
     "vue": "^3.3.4",

--- a/projects/yeoman-ui/packages/generator-foodq/package.json
+++ b/projects/yeoman-ui/packages/generator-foodq/package.json
@@ -18,7 +18,7 @@
     "yeoman.png"
   ],
   "dependencies": {
-    "@sap-devx/yeoman-ui-types": "^1.25.0",
+    "@sap-devx/yeoman-ui-types": "workspace:^",
     "chalk-pipe": "^4.0.0",
     "datauri": "^3.0.0",
     "inquirer": "^7.3.3",


### PR DESCRIPTION
Prevents `pnpm i --lockfile-only` from failing during `ci:version` when changeset bumps @sap-devx/yeoman-ui-types to a version not yet on npm.