### PR TITLE
build: ignore yeoman-env-v3 in releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,6 @@
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@sap-devx/yeoman-ui-root"],
+  "ignore": ["@sap-devx/yeoman-ui-root", "yeoman-env-v3"],
   "privatePackages": { "version": true, "tag": true }
 }


### PR DESCRIPTION
This "internal" package's version should be synced to the actual version of yeoman-env it is wrapping