### PR TITLE
build: ignore yeoman-env wrapper

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,6 @@
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@sap-devx/yeoman-ui-root"],
+  "ignore": ["@sap-devx/yeoman-ui-root", "yeoman-env-v3"],
   "privatePackages": { "version": true, "tag": true }
 }

--- a/.changeset/puny-wombats-think.md
+++ b/.changeset/puny-wombats-think.md
@@ -1,6 +1,5 @@
 ---
 "yeoman-ui": minor
-"yeoman-env-v3": patch
 ---
 
 Support yeoman environment v3 and v6


### PR DESCRIPTION
the version of internal yeoman-env-v3 should be aligned to the wrapped yeoman-env version, not any internal repo version