### PR TITLE
fix(changeset): ignore private vscode-logging examples

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,12 @@
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@sap-devx/yeoman-ui-root", "yeoman-env-v3"],
+  "ignore": [
+    "@sap-devx/yeoman-ui-root",
+    "yeoman-env-v3",
+    "vscode-logging-extension-example",
+    "vscode-logging-extension-wrapper-example",
+    "@vscode-logging/library-example"
+  ],
   "privatePackages": { "version": true, "tag": true }
 }


### PR DESCRIPTION
## What
Add the three private `vscode-logging` example packages to the Changesets `ignore` list:
`vscode-logging-extension-example`, `vscode-logging-extension-wrapper-example`, `@vscode-logging/library-example`.

## Why
The main `Release` workflow went red after the migration (#583) at the **Upload VSIX to releases** step with `No release found for <example>@<version>`.

Root cause: the examples are `private` and the config sets `privatePackages: { tag: true }`, so the release flow tagged them and listed them in `publishedPackages`. `scripts/upload-vsix-to-releases.mjs` then iterates that list and errors when a listed package has no matching GitHub Release - the examples have none. (The `.vsix` attach is a separate, conditional step; the throw is purely about a published package with no matching Release.)

The `Release` workflow only runs on push to `main`, so branch CI never exercised this path.

## Behaviour
With the examples in `ignore`, they are excluded from versioning and tagging, never enter `publishedPackages`, and `upload-vsix` no longer fails. No changeset here, so no packages are published by this PR - it only fixes the pipeline.

Shachar deleted the stale example tags on origin, so this run also serves as a live check that `ignore` keeps them from being re-tagged.
