### PR TITLE
chore(vscode-logging): maintenance release from new monorepo location

### DIFF
--- a/.changeset/vscode-logging-maintenance-release.md
+++ b/.changeset/vscode-logging-maintenance-release.md
@@ -1,0 +1,7 @@
+---
+"@vscode-logging/logger": patch
+"@vscode-logging/types": patch
+"@vscode-logging/wrapper": patch
+---
+
+Maintenance release from the new monorepo location. No functional changes.


### PR DESCRIPTION
## What
Adds a changeset that cuts a patch release of the three `vscode-logging` packages from their new monorepo home (`projects/vscode-logging`): `@vscode-logging/logger`, `@vscode-logging/types`, `@vscode-logging/wrapper`. They are a `fixed` group, so they version together to `2.0.10`.

## Why
The migration (#583) relocated the packages without releasing them. This is the separate post-merge release step (matching the mta-tools #554 and yeoman-ui #535 pattern). It is a pure relocation, so a patch, and it validates that the release pipeline works end to end from the new location.

## Behaviour
On merge, the Changesets action opens a "Version Packages" PR (bumps versions, writes changelogs). No publish happens yet. When that Version PR is merged, the packages publish to npm via OIDC and GitHub Releases are created.

Because the trio sits in a `fixed` group and `updateInternalDependencies` is `patch`, this cascades through the other fixed groups into a full release wave (16 packages):

- `@vscode-logging/logger` 2.0.9 -> 2.0.10, `types` 2.0.8 -> 2.0.10, `wrapper` 2.0.9 -> 2.0.10
- `app-studio-toolkit` + `@sap-devx/app-studio-toolkit-types` + `sample-action-client` + `vscode-using-workspace-api` 2.11.4 -> 2.11.5
- `app-studio-remote-access` 4.1.2 -> 4.1.3
- `@sap-devx/npm-dependencies-validation` + `vscode-dependencies-validation` 3.0.3 -> 3.0.4
- `vscode-deps-upgrade-tool` + `vscode-using-upgrade-tool` 5.0.2 -> 5.0.3
- `vscode-disk-usage` 2.3.3 -> 2.3.4
- `vscode-mta-tools` 1.4.11 -> 1.4.12
- `yeoman-ui` + `yeoman-ui-frontend` -> 1.27.1

Notes for review:
- `types` jumps 2.0.8 -> 2.0.10 (skips 2.0.9) because the fixed group lock-steps it to logger and wrapper.
- The private `vscode-logging` examples stay at their current versions (they are in the changeset `ignore` list), so they are not re-tagged and the upload-vsix step is not affected.
