### PR TITLE
build: only bump with workspace protocol

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,7 @@
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": [
     "@sap-devx/yeoman-ui-root",
     "yeoman-env-v3",


### PR DESCRIPTION
This way we can control which inter monorepo deps are automatically bumped
and which are consumed from npmjs (e.g. library like vscode-logging).
This avoids cascading re-release of most of the monorepo everytime vscode-logging is released