### PR TITLE
build: pin vscode-logging

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,8 +684,8 @@ importers:
         specifier: 1.2.15
         version: 1.2.15
       '@vscode-logging/logger':
-        specifier: workspace:*
-        version: link:../vscode-logging/packages/logger
+        specifier: 2.0.9
+        version: 2.0.9
       comment-json:
         specifier: 4.1.1
         version: 4.1.1

--- a/projects/vscode-mta-tools/package.json
+++ b/projects/vscode-mta-tools/package.json
@@ -215,7 +215,7 @@
     "lodash": "4.17.21",
     "comment-json": "4.1.1",
     "fs-extra": "10.0.0",
-    "@vscode-logging/logger": "workspace:*",
+    "@vscode-logging/logger": "2.0.9",
     "@sap/swa-for-sapbas-vsx": "1.2.15",
     "@sap/mta-lib": "1.7.4",
     "@sap/cf-tools": "2.0.1",


### PR DESCRIPTION
Even after consolidation of vscode-logging into this monorepo we want to initially keep
the update process separate:
1. First vscode-logging update
2. Second various *.vsix packages updates 