### PR TITLE
chore(changeset): bump only workspace-protocol deps on release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -29,5 +29,9 @@
     "vscode-logging-extension-wrapper-example",
     "@vscode-logging/library-example"
   ],
-  "privatePackages": { "version": true, "tag": true }
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  },
+  "bumpVersionsWithWorkspaceProtocolOnly": true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,8 +684,8 @@ importers:
         specifier: 1.2.15
         version: 1.2.15
       '@vscode-logging/logger':
-        specifier: workspace:*
-        version: link:../vscode-logging/packages/logger
+        specifier: 2.0.9
+        version: 2.0.9
       comment-json:
         specifier: 4.1.1
         version: 4.1.1

--- a/projects/vscode-mta-tools/package.json
+++ b/projects/vscode-mta-tools/package.json
@@ -215,7 +215,7 @@
     "lodash": "4.17.21",
     "comment-json": "4.1.1",
     "fs-extra": "10.0.0",
-    "@vscode-logging/logger": "workspace:*",
+    "@vscode-logging/logger": "2.0.9",
     "@sap/swa-for-sapbas-vsx": "1.2.15",
     "@sap/mta-lib": "1.7.4",
     "@sap/cf-tools": "2.0.1",


### PR DESCRIPTION
## What
Add `bumpVersionsWithWorkspaceProtocolOnly: true` to `.changeset/config.json`, and flip `vscode-mta-tools`'s `@vscode-logging/logger` dependency from `workspace:*` to the pinned `2.0.9`.

## Why
The vscode-logging maintenance release (the changeset already on main) died in the `ci:version` step: `changeset version` rewrote exact-pin consumers to the not-yet-published `2.0.10`, then `pnpm i --lockfile-only` tried to fetch it from the registry and failed.

With this flag, a release only bumps packages whose intra-repo dependencies use the workspace protocol. Inside `projects/vscode-logging` everything stays `workspace:*`; every external consumer stays pinned. `vscode-mta-tools` was the only external ref still on `workspace:*`, so it is pinned to match the rule.

This aligns with the behaviour before the monorepo integration: updating vscode-logging in other repos was always a two step process, so there is no dev-flow regression.

## Behaviour
Verified locally with the full `ci:version` (both halves): exit 0, and only the three vscode-logging packages bump (`logger`/`types`/`wrapper` -> `2.0.10`). No cascade into unrelated packages, no registry-fetch deadlock. On merge the Changesets action opens the Version PR; merging that publishes the trio.
