### PR TITLE
chore(guided-development): maintenance release from new monorepo location

### DIFF
--- a/.changeset/guided-development-maintenance-release.md
+++ b/.changeset/guided-development-maintenance-release.md
@@ -1,0 +1,6 @@
+---
+"guided-development": patch
+"guided-development-frontend": patch
+---
+
+Maintenance release from the new monorepo location. No functional changes.


### PR DESCRIPTION
## What

Adds a changeset that cuts a **patch** release of the guided-development `fixed` group from its new monorepo home (`projects/guided-development`): `guided-development` and `guided-development-frontend`.

## Why

The migration (#601) relocated the packages without releasing them. This is the separate post-merge release step, matching the vscode-logging (#590) and yeoman-ui (#535) pattern. It is a pure relocation, so a patch, and it validates the release pipeline works end to end from the new location.

## Behaviour

On merge, the Changesets action opens a "Version Packages" PR (bumps versions, writes changelogs). No publish happens yet. When that Version PR is merged, the packages version together (fixed group) and the backend VSIX is uploaded to its GitHub Release for `bas-tools`.

Verified locally with the full `pnpm run ci:version` dry-run: only the two guided-development packages bump (0.2.8 and 0.1.2), no cascade into other fixed groups, lockfile step clean. `@sap_oss/guided-development-types` stays in `ignore` (deferred, tracked separately).